### PR TITLE
issue-11 Caches slack messages sent to avoid duplicate

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "glob": "^7.1.2",
     "lodash": "^4.17.4",
     "mustache": "^2.3.0",
+    "node-cache": "^4.2.0",
     "secure-compare": "^3.0.1",
     "winston": "^2.4.0",
     "yamljs": "^0.3.0"

--- a/src/lib/slack_api_utils.js
+++ b/src/lib/slack_api_utils.js
@@ -1,13 +1,21 @@
 require('dotenv').config();
 const client = (require('./slack_client_factory.js')).getSlackApiClient();
 const logger = require('./logger');
+const NodeCache = require( "node-cache" );
+const recentlySentMessages = new NodeCache( { checkperiod: 120 } );
 
 const sendSlackMessage = async (to, slackMsg) => {
-    logger.info("Sending slack message to " + to);
-    try {
-        await client.chat.postMessage(`@${to}`, null, {'attachments': slackMsg});
-    } catch (err) {
-        logger.error(`Could not send slack message to ${to}: ${err}`);
+    const cacheKey = to + slackMsg;
+    if (recentlySentMessages.get(cacheKey) === undefined) {
+        recentlySentMessages.set(cacheKey, "", 300); // Up to 5 minutes of duplicate cache
+        logger.info("Sending slack message to " + to);
+        try {
+            await client.chat.postMessage(`@${to}`, null, {'attachments': slackMsg});
+        } catch (err) {
+            logger.error(`Could not send slack message to ${to}: ${err}`);
+        }
+    } else {
+        logger.info(`Skipping sending duplicate slack message to ${to}`);
     }
 };
 

--- a/test/lib/slack_api.spec.js
+++ b/test/lib/slack_api.spec.js
@@ -4,7 +4,7 @@ const sinon = require('sinon');
 
 describe('slack api', function() {
     let slackClient, spy;
-    before(function() {
+    beforeEach(function() {
         mockery.enable({
             useCleanCache: true,
             warnOnReplace: false,
@@ -15,12 +15,24 @@ describe('slack api', function() {
         const mockedFactory = { getSlackApiClient: () => {return slackClient;}};
         mockery.registerMock('./slack_client_factory.js', mockedFactory);
     });
-    after(function() {
+    afterEach(function() {
         mockery.disable();
     });
     it('sends slack message adding @ on the recipient', function() {
         const slack = require('../../src/lib/slack_api_utils');
         slack.sendSlackMessage('lorenzo.fundaro', 'Hello !');
         assert.isTrue(spy.calledWithMatch('@lorenzo.fundaro' ));
+    });
+    it('skips duplicated slack messages to the same user', function() {
+        const slack = require('../../src/lib/slack_api_utils');
+        slack.sendSlackMessage('lorenzo.fundaro', 'This will be sent once');
+        slack.sendSlackMessage('lorenzo.fundaro', 'This will be sent once');
+        assert.isTrue(spy.calledOnce);
+    });
+    it('does not skip duplicated slack messages to different users', function() {
+        const slack = require('../../src/lib/slack_api_utils');
+        slack.sendSlackMessage('lorenzo.fundaro', 'This will be sent twice');
+        slack.sendSlackMessage('tbillet', 'This will be sent twice');
+        assert.isTrue(spy.calledTwice);
     });
 });


### PR DESCRIPTION
Solving [Issue #11](https://github.com/PRDog/prdog/issues/11) _Duplicate review request_
- Using `node-cache` to keep recently sent messages and ignore duplicates
- Key is built from the message content and the slack recipient name
- Cache TTL is 5 minutes.